### PR TITLE
Shebang: Use the proper one for python2.x

### DIFF
--- a/createMakefile.py
+++ b/createMakefile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#! /usr/bin/env python2
 
 import os
 import sys


### PR DESCRIPTION
Some Linux distros use python3 as default python version for /usr/bin/python. Your code isn't compliant to this version according to the print keyword syntax.

On others, it might be located somewhere else. For instance, under /usr/local/bin/python.
